### PR TITLE
add new variables to MPC Telemetry

### DIFF
--- a/src/common/lmpc_msgs/msg/MPCTelemetry.msg
+++ b/src/common/lmpc_msgs/msg/MPCTelemetry.msg
@@ -20,3 +20,18 @@ float64[] control
 
 # solve time
 float64 solve_time 0.0
+
+# reference trajectory
+float64[] reference_trajectory
+
+# reference input
+float64[] reference_input
+
+# bank angle list
+float64[] banks
+
+# curvature list
+float64[] curvatures
+
+# Trajectory Command
+lmpc_msgs/TrajectoryCommand trajectory_cmd


### PR DESCRIPTION
Add the following fields to MPC telemetry: reference trajectory, reference input, banks, curvatures, all float64[], and [TrajectoryCommand]